### PR TITLE
添加自主选择扩展功能，添加tideways_xhprof

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -5,15 +5,20 @@
 return array(
     'debug' => false,
     'mode' => 'development',
+    /*
+     * support extension: uprofiler, tideways, xhprof
+     * default: xhprof
+     */
+    'extension' => 'xhprof',
 
     // Can be either mongodb or file.
-    /* 
+    /*
     'save.handler' => 'file',
     'save.handler.filename' => dirname(__DIR__) . '/cache/' . 'xhgui.data.' . microtime(true) . '_' . substr(md5($url), 0, 6),
     */
     'save.handler' => 'mongodb',
 
-    // Needed for file save handler. Beware of file locking. You can adujst this file path 
+    // Needed for file save handler. Beware of file locking. You can adujst this file path
     // to reduce locking problems (eg uniqid, time ...)
     //'save.handler.filename' => __DIR__.'/../data/xhgui_'.date('Ymd').'.dat',
     'db.host' => 'mongodb://127.0.0.1:27017',

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -6,7 +6,7 @@ return array(
     'debug' => false,
     'mode' => 'development',
     /*
-     * support extension: uprofiler, tideways, xhprof
+     * support extension: uprofiler, tideways_xhprof, tideways, xhprof
      * default: xhprof
      */
     'extension' => 'xhprof',

--- a/external/header.php
+++ b/external/header.php
@@ -89,6 +89,8 @@ if (!isset($_SERVER['REQUEST_TIME_FLOAT'])) {
 $extension = Xhgui_Config::read('extension');
 if ($extension == 'uprofiler' && extension_loaded('uprofiler')) {
     uprofiler_enable(UPROFILER_FLAGS_CPU | UPROFILER_FLAGS_MEMORY);
+} else if ($extension == 'tideways_xhprof' && extension_loaded('tideways_xhprof')) {
+    tideways_xhprof_enable(TIDEWAYS_XHPROF_FLAGS_MEMORY | TIDEWAYS_XHPROF_FLAGS_MEMORY_MU | TIDEWAYS_XHPROF_FLAGS_MEMORY_PMU | TIDEWAYS_XHPROF_FLAGS_CPU);
 } else if ($extension == 'tideways' && extension_loaded('tideways')) {
     tideways_enable(TIDEWAYS_FLAGS_CPU | TIDEWAYS_FLAGS_MEMORY | TIDEWAYS_FLAGS_NO_SPANS);
 } else {
@@ -104,6 +106,8 @@ register_shutdown_function(
         $extension = Xhgui_Config::read('extension');
         if ($extension == 'uprofiler' && extension_loaded('uprofiler')) {
             $data['profile'] = uprofiler_disable();
+        } else if ($extension == 'tideways_xhprof' && extension_loaded('tideways_xhprof')) {
+            $data['profile'] = tideways_xhprof_disable();
         } else if ($extension == 'tideways' && extension_loaded('tideways')) {
             $data['profile'] = tideways_disable();
         } else {

--- a/external/header.php
+++ b/external/header.php
@@ -86,9 +86,10 @@ if (!isset($_SERVER['REQUEST_TIME_FLOAT'])) {
     $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true);
 }
 
-if (extension_loaded('uprofiler')) {
+$extension = Xhgui_Config::read('extension');
+if ($extension == 'uprofiler' && extension_loaded('uprofiler')) {
     uprofiler_enable(UPROFILER_FLAGS_CPU | UPROFILER_FLAGS_MEMORY);
-} else if (extension_loaded('tideways')) {
+} else if ($extension == 'tideways' && extension_loaded('tideways')) {
     tideways_enable(TIDEWAYS_FLAGS_CPU | TIDEWAYS_FLAGS_MEMORY | TIDEWAYS_FLAGS_NO_SPANS);
 } else {
     if (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION > 4) {
@@ -100,9 +101,10 @@ if (extension_loaded('uprofiler')) {
 
 register_shutdown_function(
     function () {
-        if (extension_loaded('uprofiler')) {
+        $extension = Xhgui_Config::read('extension');
+        if ($extension == 'uprofiler' && extension_loaded('uprofiler')) {
             $data['profile'] = uprofiler_disable();
-        } else if (extension_loaded('tideways')) {
+        } else if ($extension == 'tideways' && extension_loaded('tideways')) {
             $data['profile'] = tideways_disable();
         } else {
             $data['profile'] = xhprof_disable();


### PR DESCRIPTION
system: ubuntu 16.04
php version: php 7.0.22

1.程序默认按顺序选择扩展，导致只有关闭优先级高的扩展才能使用优先级低的扩展。
2.添加tideways_xhprof扩展，此扩展是官方开源版，用于兼容xhprof。详情见：https://github.com/tideways/php-profiler-extension