### PR TITLE
fix bug

### DIFF
--- a/src/Xhgui/Profiles.php
+++ b/src/Xhgui/Profiles.php
@@ -169,7 +169,9 @@ class Xhgui_Profiles
                 )
             ),
             array('$sort' => array('_id' => 1)),
-        ));
+            ),
+            array('cursor' => array('batchSize' => 0))
+        );
 
         if (empty($results['result'])) {
             return array();


### PR DESCRIPTION
The 'cursor' option is required, except for aggregate with the explain argument