### PR TITLE
简单调整

### DIFF
--- a/src/Xhgui/Controller/Run.php
+++ b/src/Xhgui/Controller/Run.php
@@ -212,7 +212,7 @@ class Xhgui_Controller_Run extends Xhgui_Controller
             'base_url' => 'run.compare',
             'base_run' => $baseRun,
             'head_run' => $headRun,
-            'candidates' => $candidates,
+            'candidates' => $candidates ? $candidates : [],
             'url_params' => $request->get(),
             'date_format' => $this->_app->config('date.format'),
             'comparison' => $comparison,

--- a/webroot/index.php
+++ b/webroot/index.php
@@ -1,4 +1,5 @@
 <?php
+date_default_timezone_set('PRC');
 require dirname(__DIR__) . '/src/bootstrap.php';
 
 $di = new Xhgui_ServiceContainer();


### PR DESCRIPTION
1.在入口设置时区,防止时间显示不准确.
2.调整一处判断解决在高版本PHP下报错的问题.